### PR TITLE
Add opentelemetry tracing on gRPC calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,6 +62,7 @@ func main() {
 		driver.WithAwsSdkDebugLog(options.ControllerOptions.AwsSdkDebugLog),
 		driver.WithWarnOnInvalidTag(options.ControllerOptions.WarnOnInvalidTag),
 		driver.WithUserAgentExtra(options.ControllerOptions.UserAgentExtra),
+		driver.WithOtelTracing(options.ServerOptions.EnableOtelTracing),
 	)
 	if err != nil {
 		klog.ErrorS(err, "failed to create driver")

--- a/cmd/options/server_options.go
+++ b/cmd/options/server_options.go
@@ -28,9 +28,12 @@ type ServerOptions struct {
 	Endpoint string
 	// HttpEndpoint is the endpoint that the HTTP server for metrics should listen on.
 	HttpEndpoint string
+	// EnableOtelTracing enables opentelemetry tracing.
+	EnableOtelTracing bool
 }
 
 func (s *ServerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.Endpoint, "endpoint", driver.DefaultCSIEndpoint, "Endpoint for the CSI driver server")
 	fs.StringVar(&s.HttpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for metrics will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
+	fs.BoolVar(&s.EnableOtelTracing, "enable-otel-tracing", false, "To enable opentelemetry tracing for the driver. The tracing is disabled by default. Configure the exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT")
 }

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -53,6 +53,8 @@ func TestGetOptions(t *testing.T) {
 		var VolumeAttachLimit int64 = 42
 		userAgentExtraFlag := "user-agent-extra"
 		userAgentExtraFlagValue := "test"
+		otelTracingFlagName := "enable-otel-tracing"
+		otelTracingFlagValue := true
 
 		args := append([]string{
 			"aws-ebs-csi-driver",
@@ -60,6 +62,7 @@ func TestGetOptions(t *testing.T) {
 
 		if withServerOptions {
 			args = append(args, "--"+endpointFlagName+"="+endpoint)
+			args = append(args, "--"+otelTracingFlagName+"="+strconv.FormatBool(otelTracingFlagValue))
 		}
 		if withControllerOptions {
 			args = append(args, "--"+extraTagsFlagName+"="+extraTagKey+"="+extraTagValue)
@@ -82,6 +85,10 @@ func TestGetOptions(t *testing.T) {
 			}
 			if options.ServerOptions.Endpoint != endpoint {
 				t.Fatalf("expected endpoint to be %q but it is %q", endpoint, options.ServerOptions.Endpoint)
+			}
+			otelTracingFlag := flagSet.Lookup(otelTracingFlagName)
+			if otelTracingFlag == nil {
+				t.Fatalf("expected %q flag to be added but it is not", otelTracingFlagName)
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,10 @@ require (
 	github.com/onsi/gomega v1.27.8
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1
+	go.opentelemetry.io/otel v1.15.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.1
+	go.opentelemetry.io/otel/sdk v1.15.1
 	golang.org/x/sys v0.9.0
 	google.golang.org/grpc v1.56.0
 	google.golang.org/protobuf v1.30.0
@@ -89,14 +93,10 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.9 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.9 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.9 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1 // indirect
-	go.opentelemetry.io/otel v1.15.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.1 // indirect
 	go.opentelemetry.io/otel/metric v0.38.1 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.1 // indirect
 	go.opentelemetry.io/otel/trace v1.15.1 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/awslabs/volume-modifier-for-k8s/pkg/rpc"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 )
@@ -69,6 +70,7 @@ type DriverOptions struct {
 	awsSdkDebugLog      bool
 	warnOnInvalidTag    bool
 	userAgentExtra      string
+	otelTracing         bool
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -123,8 +125,17 @@ func (d *Driver) Run() error {
 		}
 		return resp, err
 	}
+
+	grpcInterceptor := grpc.UnaryInterceptor(logErr)
+	if d.options.otelTracing {
+		if err := initOtelTracing(); err != nil {
+			return err
+		}
+		grpcInterceptor = grpc.ChainUnaryInterceptor(logErr, otelgrpc.UnaryServerInterceptor())
+	}
+
 	opts := []grpc.ServerOption{
-		grpc.UnaryInterceptor(logErr),
+		grpcInterceptor,
 	}
 	d.srv = grpc.NewServer(opts...)
 
@@ -206,5 +217,11 @@ func WithWarnOnInvalidTag(warnOnInvalidTag bool) func(*DriverOptions) {
 func WithUserAgentExtra(userAgentExtra string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.userAgentExtra = userAgentExtra
+	}
+}
+
+func WithOtelTracing(enableOtelTracing bool) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.otelTracing = enableOtelTracing
 	}
 }

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -103,3 +103,12 @@ func TestWithUserAgentExtra(t *testing.T) {
 		t.Fatalf("expected userAgentExtra option got set to %s but is set to %s", userAgentExtra, options.userAgentExtra)
 	}
 }
+
+func TestWithOtelTracing(t *testing.T) {
+	var enableOtelTracing bool = true
+	options := &DriverOptions{}
+	WithOtelTracing(enableOtelTracing)(options)
+	if options.otelTracing != enableOtelTracing {
+		t.Fatalf("expected otelTracing option got set to %v but is set to %v", enableOtelTracing, options.otelTracing)
+	}
+}

--- a/pkg/driver/trace.go
+++ b/pkg/driver/trace.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"k8s.io/klog/v2"
+)
+
+func initOtelTracing() error {
+	// Setup OTLP exporter
+	ctx := context.Background()
+	exporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create the OTLP exporter: %w", err)
+	}
+
+	// Resource will auto populate spans with common attributes
+	resource, err := resource.New(ctx,
+		resource.WithFromEnv(), // pull attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables
+		resource.WithProcess(),
+		resource.WithOS(),
+		resource.WithContainer(),
+		resource.WithHost(),
+	)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create the OTLP resource, spans will lack some metadata")
+	}
+
+	// Create a trace provider with the exporter and a sampling strategy.
+	traceProvider := trace.NewTracerProvider(trace.WithBatcher(exporter), trace.WithResource(resource), trace.WithSampler(trace.ParentBased(trace.AlwaysSample())))
+
+	// Register the trace provider and propagator as global.
+	otel.SetTracerProvider(traceProvider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a new cli flag `enable-otel-tracing` to add some basic tracing on the gRPC calls received by the driver. The tracing is implemented using opentelemetry libraries. The tracing is disabled by default because the overhead it causes may not be wanted by everyone.

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
