### PR TITLE
[CMPT-2396] Pin major version in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,3 +20,4 @@ jobs:
         github_token: ${{ secrets.WORKFLOW_TOKEN }}
         upstream_repo: kubernetes-sigs/aws-ebs-csi-driver
         date_suffix: "%Y%V"
+        major_version: "1"


### PR DESCRIPTION
This avoids bumping the major version when rebasing the datadog branch and producing new tags