### PR TITLE
[local] Add xfs utils to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,8 @@ RUN OS=$TARGETOS ARCH=$TARGETARCH make
 
 FROM $BASE_IMAGE
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
+# Install xfs tools for xfs filesystem support in EBS volumes
+USER root
+RUN clean-apt install xfsprogs
+USER dog
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Add xfs utils to our base image so that we can create xfs EBS volumes

**What is this PR about? / Why do we need it?**

**What testing is done?** 
