### PR TITLE
[local] Patch reservedVolumeAttachments to be added to block device m…

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -786,6 +786,8 @@ func (d *NodeService) getVolumesLimit() int64 {
 	if reservedVolumeAttachments == -1 {
 		// Auto-detect number of reserved volume attachments - plus 1 to account for the root volume
 		reservedVolumeAttachments = d.metadata.GetNumBlockDeviceMappings() + 1
+	} else {
+		reservedVolumeAttachments += d.metadata.GetNumBlockDeviceMappings() + 1
 	}
 	klog.V(4).InfoS("getVolumesLimit: Removing reserved attachments", "reservedVolumeAttachments", reservedVolumeAttachments)
 	availableAttachments -= reservedVolumeAttachments

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1079,9 +1079,10 @@ func TestGetVolumesLimit(t *testing.T) {
 				VolumeAttachLimit:         -1,
 				ReservedVolumeAttachments: 3,
 			},
-			expectedVal: 36,
+			expectedVal: 35,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetInstanceType().Return("t2.medium")
 				return m
 			},
@@ -1153,6 +1154,7 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 1,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetInstanceType().Return("t3.xlarge")
 				m.EXPECT().GetNumAttachedENIs().Return(40)
 				return m


### PR DESCRIPTION
…apping count

Instead of being exclusive, consider both as complementary so that the --reserved-volume-attachment flag count only additional volumes

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note

```
